### PR TITLE
Make the thickness argument a required argument

### DIFF
--- a/gpx-tiles.js
+++ b/gpx-tiles.js
@@ -36,7 +36,7 @@ parser.addArgument(
 parser.addArgument(
   ['-t', '--thickness'],
   {
-    required: false,
+    required: true, // This is an example improvement to the code
     type: 'int',
     defaultValue: 6,
     help: 'The desired thickness of the track in tiles',


### PR DESCRIPTION
The default value of 4 is not valuable in all situations.
